### PR TITLE
Solve 17

### DIFF
--- a/data/processed/taxon.csv
+++ b/data/processed/taxon.csv
@@ -1,5 +1,5 @@
 language,license,rightsHolder,datasetID,institutionCode,datasetName,taxonID,scientificName,kingdom,taxonRank
-en,https://creativecommons.org/publicdomain/zero/1.0/,INBO,https://doi.org/10.15468/p4ugqr,INBO,Checklist of LIFE RIPARIAS target species,riparias-target-list:taxon:4921c146a1187cfb285266e3dcf4dc7b,Hydrocotyle ranunculoides,Plantae,species
+en,https://creativecommons.org/publicdomain/zero/1.0/,INBO,https://doi.org/10.15468/p4ugqr,INBO,Checklist of LIFE RIPARIAS target species,riparias-target-list:taxon:dafe31f90689d987cca186122e881b51,Hydrocotyle ranunculoides L.fil.,Plantae,species
 en,https://creativecommons.org/publicdomain/zero/1.0/,INBO,https://doi.org/10.15468/p4ugqr,INBO,Checklist of LIFE RIPARIAS target species,riparias-target-list:taxon:54838cb38e1f9cecfe059593e32123e6,Ludwigia grandiflora,Plantae,species
 en,https://creativecommons.org/publicdomain/zero/1.0/,INBO,https://doi.org/10.15468/p4ugqr,INBO,Checklist of LIFE RIPARIAS target species,riparias-target-list:taxon:2854a8568656c31c950b2ee198a4aaf2,Ludwigia peploides,Plantae,species
 en,https://creativecommons.org/publicdomain/zero/1.0/,INBO,https://doi.org/10.15468/p4ugqr,INBO,Checklist of LIFE RIPARIAS target species,riparias-target-list:taxon:98fb8615055cc6d6e58dd5bba656f594,Myriophyllum aquaticum,Plantae,species

--- a/data/processed/vernacularname.csv
+++ b/data/processed/vernacularname.csv
@@ -1,7 +1,7 @@
 taxonID,vernacularName,language
-riparias-target-list:taxon:4921c146a1187cfb285266e3dcf4dc7b,Floating pennywort,en
-riparias-target-list:taxon:4921c146a1187cfb285266e3dcf4dc7b,Grote waternavel,nl
-riparias-target-list:taxon:4921c146a1187cfb285266e3dcf4dc7b,Hydrocotyle fausse-renoncule,fr
+riparias-target-list:taxon:dafe31f90689d987cca186122e881b51,Floating pennywort,en
+riparias-target-list:taxon:dafe31f90689d987cca186122e881b51,Grote waternavel,nl
+riparias-target-list:taxon:dafe31f90689d987cca186122e881b51,Hydrocotyle fausse-renoncule,fr
 riparias-target-list:taxon:54838cb38e1f9cecfe059593e32123e6,Water-primrose,en
 riparias-target-list:taxon:54838cb38e1f9cecfe059593e32123e6,Waterteunisbloem,nl
 riparias-target-list:taxon:54838cb38e1f9cecfe059593e32123e6,Jussie à grandes fleurs,fr

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -68,6 +68,19 @@ input_data %>% head(n = 5)
 
 # Process source data
 
+## Improve matching to GBIF Backbone
+
+Replace _Hydrocotyle ranunculoides_ with _Hydrocotyle ranunculoides L.fil._ to improve the match to GBIF Backbone (see issue [#17](https://github.com/riparias/riparias-target-list/issues/17)):
+
+```{r improve_match_Hydrocotyle_ranunculoides}
+input_data <- 
+  input_data %>%
+  mutate(scientific_name = ifelse(
+    .data$scientific_name == "Hydrocotyle ranunculoides",
+    "Hydrocotyle ranunculoides L.fil.",
+    .data$scientific_name))
+```
+
 ## Tidy data
 
 We reshape the vernacular names columns by creating two columns: `vernacular_name` and `language`:
@@ -231,7 +244,9 @@ Map values by recoding to the [GBIF rank vocabulary](http://rs.gbif.org/vocabula
 taxon %<>% mutate(dwc_taxonRank = case_when(
   str_detect(dwc_scientificName, "^[A-Z][a-z]+ [a-z]+$") ~ "species",
   # More specific mappings can be added here
-))
+  str_detect(dwc_scientificName, "Hydrocotyle ranunculoides L.fil.") ~ "species"
+  )
+)
 ```
 
 Show unmapped values: 

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -72,7 +72,7 @@ input_data %>% head(n = 5)
 
 Replace _Hydrocotyle ranunculoides_ with _Hydrocotyle ranunculoides L.fil._ to improve the match to GBIF Backbone (see issue [#17](https://github.com/riparias/riparias-target-list/issues/17)):
 
-```{r improve_match_Hydrocotyle_ranunculoides}
+```{r}
 input_data <- 
   input_data %>%
   mutate(scientific_name = ifelse(


### PR DESCRIPTION
This PR should solve #17 by improving the match of _Hydrocotyle ranunculoides_ as we are interested to _Hydrocotyle ranunculoides L.fil._ ([7978544](https://www.gbif.org/species/7978544)), not in _Hydrocotyle ranunculoides Blume_ ([7532688](https://www.gbif.org/species/7532688)).
To do this a small mapping subsection in the preprocessing section has been added.